### PR TITLE
fix project to stable pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,6 @@
     "onlyBuiltDependencies": [
       "esbuild"
     ]
-  }
+  },
+  "packageManager": "pnpm@9.15.9"
 }


### PR DESCRIPTION
This makes `pnpm install` deterministic. On my default version of `pnpm` from the webapp (8.6.12) I could not do `pnpm install --frozen-lockfile`, and `pnpm install` resulted in a different lockfile that in turn resulted in failing tests.