### PR TITLE
bug(demo): fetch dependency missing

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -8,7 +8,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "@airbyte-embedded/airbyte-embedded-widget": "workspace:*",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.42.1",

--- a/demo/server.js
+++ b/demo/server.js
@@ -1,3 +1,4 @@
+const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
 const express = require("express");
 
 // Disable SSL verification for development


### PR DESCRIPTION
## WHAT

I found this problem trying to run the backend.

```
at /Users/aldogonzalez/dev/airbyte-embedded-widget/demo/server.js:49:22
at Layer.handle [as handle_request] (/Users/aldogonzalez/dev/airbyte-embedded-widget/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/layer.js:95:5)
at next (/Users/aldogonzalez/dev/airbyte-embedded-widget/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/route.js:149:13)
at Route.dispatch (/Users/aldogonzalez/dev/airbyte-embedded-widget/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/route.js:119:3)
at Layer.handle [as handle_request] (/Users/aldogonzalez/dev/airbyte-embedded-widget/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/layer.js:95:5)
```

Error Details
Error Type: ReferenceError
Error Message: fetch is not defined
File: /Users/aldogonzalez/dev/airbyte-embedded-widget/demo/server.js
Line: 49:22

## HOW

Added node-fetch to dependencies. 