### PR TITLE
feat(demo): force engine version

### DIFF
--- a/demo/.npmrc
+++ b/demo/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/demo/package.json
+++ b/demo/package.json
@@ -16,5 +16,8 @@
     "dotenv": "^16.4.7",
     "prettier": "^3.5.3",
     "typescript": "5.8.2"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
I had problems running as fetch was not available in Node till versions>18. This should help people trying the widget in the demo.

```
at /Users/aldogonzalez/dev/airbyte-embedded-widget/demo/server.js:49:22
at Layer.handle [as handle_request] (/Users/aldogonzalez/dev/airbyte-embedded-widget/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/layer.js:95:5)
at next (/Users/aldogonzalez/dev/airbyte-embedded-widget/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/route.js:149:13)
at Route.dispatch (/Users/aldogonzalez/dev/airbyte-embedded-widget/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/route.js:119:3)
at Layer.handle [as handle_request] (/Users/aldogonzalez/dev/airbyte-embedded-widget/node_modules/.pnpm/express@4.19.2/node_modules/express/lib/router/layer.js:95:5)
```

Error Details
Error Type: ReferenceError
Error Message: fetch is not defined
File: /Users/aldogonzalez/dev/airbyte-embedded-widget/demo/server.js
Line: 49:22