### PR TITLE
publish new version to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airbyte-embedded/airbyte-embedded-widget",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Embedded widget for Airbyte",
   "type": "module",
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
released a version with type definitions, but did not update the package.json so it is not live on npm.